### PR TITLE
Renaming execution profiles

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0b11
+current_version = 0.1.0b12
 commit = True
 tag = True
 parse = ^

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = qiskit-qir
-version = 0.1.0b11
+version = 0.1.0b12
 author = Microsoft
 author_email = que-contacts@microsoft.com
 description = Qiskit to QIR translator

--- a/src/qiskit_qir/__init__.py
+++ b/src/qiskit_qir/__init__.py
@@ -4,7 +4,7 @@
 ##
 __author__ = """Microsoft Corporation"""
 __email__ = 'que-contacts@microsoft.com'
-__version__ = '0.1.0b11'
+__version__ = '0.1.0b12'
 
 from qiskit_qir.translate import to_qir, to_qir_bitcode
 from qiskit_qir.visitor import SUPPORTED_INSTRUCTIONS

--- a/src/qiskit_qir/translate.py
+++ b/src/qiskit_qir/translate.py
@@ -6,7 +6,7 @@ from qiskit_qir.elements import QiskitModule
 from qiskit_qir.visitor import BasicQisVisitor
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 
-def to_qir(circuit: QuantumCircuit, profile: str = "AdaptiveProfileExecution", **kwargs) -> str:
+def to_qir(circuit: QuantumCircuit, profile: str = "AdaptiveExecution", **kwargs) -> str:
     r"""Converts the Qiskit QuantumCircuit to QIR as a string
 
     :param circuit:
@@ -33,7 +33,7 @@ def to_qir(circuit: QuantumCircuit, profile: str = "AdaptiveProfileExecution", *
     return visitor.ir()
 
 
-def to_qir_bitcode(circuit: QuantumCircuit, profile: str = "AdaptiveProfileExecution", **kwargs) -> bytes:
+def to_qir_bitcode(circuit: QuantumCircuit, profile: str = "AdaptiveExecution", **kwargs) -> bytes:
     r"""Converts the Qiskit QuantumCircuit to QIR bitcode as bytes
 
     :param circuit:

--- a/src/qiskit_qir/visitor.py
+++ b/src/qiskit_qir/visitor.py
@@ -54,7 +54,7 @@ class QuantumCircuitElementVisitor(metaclass=ABCMeta):
 
 
 class BasicQisVisitor(QuantumCircuitElementVisitor):
-    def __init__(self, profile: str = "AdaptiveProfileExecution", kwargs = {}):
+    def __init__(self, profile: str = "AdaptiveExecution", kwargs = {}):
         self._module = None
         self._builder = None
         self._qubit_labels = {}
@@ -282,9 +282,9 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
 
     def _map_profile_to_capabilities(self, profile: str):
         value = profile.strip().lower()
-        if "BaseProfileExecution".lower() == value:
+        if "BasicExecution".lower() == value:
             return Capability.NONE
-        elif "AdaptiveProfileExecution".lower() == value:
+        elif "AdaptiveExecution".lower() == value:
             return Capability.ALL
         else:
             raise UnsupportedOperation(f"The supplied profile is not supported: {profile}.")

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -113,7 +113,7 @@ def conditional_branch_on_bit():
 
 
 class ConfigurableQisVisitor(BasicQisVisitor):
-    def __init__(self, matrix: List[bool], profile: str = "AdaptiveProfileExecution"):
+    def __init__(self, matrix: List[bool], profile: str = "AdaptiveExecution"):
         BasicQisVisitor.__init__(self, profile)
         self._matrix = matrix
 
@@ -124,7 +124,7 @@ class ConfigurableQisVisitor(BasicQisVisitor):
 
 
 # Utility using new visitor and codegen matrix
-def matrix_to_qir(circuit, matrix: List[bool], profile: str = "AdaptiveProfileExecution"):
+def matrix_to_qir(circuit, matrix: List[bool], profile: str = "AdaptiveExecution"):
     module = QiskitModule.from_quantum_circuit(circuit=circuit)
     visitor = ConfigurableQisVisitor(matrix, profile)
     module.accept(visitor)
@@ -134,14 +134,14 @@ def matrix_to_qir(circuit, matrix: List[bool], profile: str = "AdaptiveProfileEx
 def test_branching_on_measurement_fails_without_required_capability(matrix):
     circuit = teleport()
     with pytest.raises(ConditionalBranchingOnResultError) as exc_info:
-        _ = matrix_to_qir(circuit, matrix, "BaseProfileExecution")
+        _ = matrix_to_qir(circuit, matrix, "BasicExecution")
 
     exception_raised = exc_info.value
     assert str(exception_raised.instruction) == "Instruction(name='x', num_qubits=1, num_clbits=0, params=[])"
     assert str(exception_raised.instruction.condition) == "(ClassicalRegister(2, 'cr'), 2)"
     assert str(exception_raised.qargs) == "[Qubit(QuantumRegister(3, 'qq'), 2)]"
     assert str(exception_raised.cargs) == "[]"
-    assert str(exception_raised.profile) == "BaseProfileExecution"
+    assert str(exception_raised.profile) == "BasicExecution"
     assert exception_raised.instruction_string == "if(cr == 2) x qq[2]"
 
 
@@ -149,28 +149,28 @@ def test_branching_on_measurement_fails_without_required_capability(matrix):
 def test_branching_on_measurement_fails_without_required_capability(matrix):
     circuit = use_conditional_branch_on_single_register_true_value()
     with pytest.raises(ConditionalBranchingOnResultError) as exc_info:
-        _ = matrix_to_qir(circuit, matrix, "BaseProfileExecution")
+        _ = matrix_to_qir(circuit, matrix, "BasicExecution")
 
     exception_raised = exc_info.value
     assert str(exception_raised.instruction) == "Instruction(name='x', num_qubits=1, num_clbits=0, params=[])"
     assert str(exception_raised.instruction.condition) == "(Clbit(ClassicalRegister(3, 'creg'), 2), True)"
     assert str(exception_raised.qargs) == "[Qubit(QuantumRegister(2, 'qreg'), 1)]"
     assert str(exception_raised.cargs) == "[]"
-    assert str(exception_raised.profile) == "BaseProfileExecution"
+    assert str(exception_raised.profile) == "BasicExecution"
     assert exception_raised.instruction_string == "if(creg[2] == True) x qreg[1]"
 
 @pytest.mark.parametrize("matrix", static_generator_variations)
 def test_branching_on_measurement_fails_without_required_capability(matrix):
     circuit = use_conditional_branch_on_single_register_false_value()
     with pytest.raises(ConditionalBranchingOnResultError) as exc_info:
-        _ = matrix_to_qir(circuit, matrix, "BaseProfileExecution")
+        _ = matrix_to_qir(circuit, matrix, "BasicExecution")
 
     exception_raised = exc_info.value
     assert str(exception_raised.instruction) == "Instruction(name='x', num_qubits=1, num_clbits=0, params=[])"
     assert str(exception_raised.instruction.condition) == "(Clbit(ClassicalRegister(3, 'creg'), 2), False)"
     assert str(exception_raised.qargs) == "[Qubit(QuantumRegister(2, 'qreg'), 1)]"
     assert str(exception_raised.cargs) == "[]"
-    assert str(exception_raised.profile) == "BaseProfileExecution"
+    assert str(exception_raised.profile) == "BasicExecution"
     assert exception_raised.instruction_string == "if(creg[2] == False) x qreg[1]"
 
 @pytest.mark.parametrize("matrix", static_generator_variations)
@@ -188,14 +188,14 @@ def test_branching_on_measurement_bit_passses_with_required_capability(matrix):
 def test_reuse_after_measurement_fails_without_required_capability(matrix):
     circuit = use_after_measure()
     with pytest.raises(QubitUseAfterMeasurementError) as exc_info:
-        _ = matrix_to_qir(circuit, matrix, "BaseProfileExecution")
+        _ = matrix_to_qir(circuit, matrix, "BasicExecution")
 
     exception_raised = exc_info.value
     assert str(exception_raised.instruction) == "Instruction(name='h', num_qubits=1, num_clbits=0, params=[])"
     assert exception_raised.instruction.condition is None
     assert str(exception_raised.qargs) == "[Qubit(QuantumRegister(2, 'qq'), 1)]"
     assert str(exception_raised.cargs) == "[]"
-    assert str(exception_raised.profile) == "BaseProfileExecution"
+    assert str(exception_raised.profile) == "BasicExecution"
     assert exception_raised.instruction_string == "h qq[1]"
 
 
@@ -208,7 +208,7 @@ def test_reuse_after_measurement_passes_with_required_capability(matrix):
 @pytest.mark.parametrize("matrix", static_generator_variations)
 def test_using_an_unread_qubit_after_measuring_passes_without_required_capability(matrix):
     circuit = use_another_after_measure()
-    _ = matrix_to_qir(circuit, matrix, "BaseProfileExecution")
+    _ = matrix_to_qir(circuit, matrix, "BasicExecution")
 
 
 @pytest.mark.parametrize("matrix", static_generator_variations)


### PR DESCRIPTION
Renaming `BaseProfileExecution` to `BasicExecution` and `AdaptiveProfileExecution` to `AdaptiveExecution`