### PR TITLE
Fix handling of cargs in BasicQisVisitor

### DIFF
--- a/src/qiskit_qir/visitor.py
+++ b/src/qiskit_qir/visitor.py
@@ -199,7 +199,7 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
             )
         for (inst, i_qargs, i_cargs) in subcircuit.data:
             mapped_qbits = [qargs[subcircuit.qubits.index(i)] for i in i_qargs]
-            mapped_clbits = [cargs[subcircuit.clbits.index] for i in i_cargs]
+            mapped_clbits = [cargs[subcircuit.clbits.index(i)] for i in i_cargs]
             _log.debug(
                 f"Processing sub-instruction {inst.name} with mapped qubits {mapped_qbits}"
             )

--- a/tests/test_circuits/__init__.py
+++ b/tests/test_circuits/__init__.py
@@ -12,6 +12,7 @@ core_tests = [
     "teleport",
     "unroll",
     "teleport_with_subroutine",
+    "measure_x_as_subroutine"
 ] + random_fixtures
 
 noop_tests = ["bernstein_vazirani_with_delay", "ghz_with_delay"]

--- a/tests/test_circuits/basic_circuits.py
+++ b/tests/test_circuits/basic_circuits.py
@@ -117,3 +117,18 @@ def ghz_with_delay():
     circuit.measure([0, 1, 2], [0, 1, 2])
 
     return circuit
+
+@pytest.fixture()
+def measure_x_as_subroutine():
+    measure_x_circuit = QuantumCircuit(1, 1, name='measure_x')
+    measure_x_circuit.h(0)
+    measure_x_circuit.measure(0, 0)
+    measure_x_circuit.h(0)
+    measure_x_gate = measure_x_circuit.to_instruction()
+    qq = QuantumRegister(1, name="qq")
+    cr = ClassicalRegister(1, name="cr")
+    circuit = QuantumCircuit(qq, cr)
+    circuit.name = "Qiskit Sample - Measure in the X-basis as a subroutine"
+    circuit.append(measure_x_gate, [0], [0])
+
+    return circuit


### PR DESCRIPTION
The unit tests in this commit fail without the change made to file src/qiskit_qir/visitor.py.

```python
File ~/ab/demos/20230404/venv/lib/python3.9/site-packages/qiskit_qir/visitor.py:189, in <listcomp>(.0)
    187 for (inst, i_qargs, i_cargs) in subcircuit.data:
    188     mapped_qbits = [qargs[subcircuit.qubits.index(i)] for i in i_qargs]
--> 189     mapped_clbits = [cargs[subcircuit.clbits.index] for i in i_cargs]
    190     _log.debug(
    191         f"Processing sub-instruction {inst.name} with mapped qubits {mapped_qbits}")
    192     self.visit_instruction(inst, mapped_qbits, mapped_clbits)

TypeError: list indices must be integers or slices, not builtin_function_or_method
```