### PR TITLE
Adding R Gate

### DIFF
--- a/src/qiskit_qir/visitor.py
+++ b/src/qiskit_qir/visitor.py
@@ -88,7 +88,7 @@ _QUANTUM_INSTRUCTIONS = [
     "z",
 ]
 
-_NOOP_INSTRUCTIONS = ["delay"]
+_NOOP_INSTRUCTIONS = ["delay", "r"]
 
 _SUPPORTED_INSTRUCTIONS = _QUANTUM_INSTRUCTIONS + _NOOP_INSTRUCTIONS
 
@@ -330,6 +330,8 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
                 qis.h(self._builder, *qubits)
             elif "reset" == instruction.name:
                 qis.reset(self._builder, qubits[0])
+            elif "r" == instruction.name:
+                qis.r(self._builder, *instruction.params, *qubits)
             elif "rx" == instruction.name:
                 qis.rx(self._builder, *instruction.params, *qubits)
             elif "ry" == instruction.name:

--- a/src/qiskit_qir/visitor.py
+++ b/src/qiskit_qir/visitor.py
@@ -88,7 +88,7 @@ _QUANTUM_INSTRUCTIONS = [
     "z",
 ]
 
-_NOOP_INSTRUCTIONS = ["delay", "r"]
+_NOOP_INSTRUCTIONS = ["delay"]
 
 _SUPPORTED_INSTRUCTIONS = _QUANTUM_INSTRUCTIONS + _NOOP_INSTRUCTIONS
 
@@ -330,8 +330,6 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
                 qis.h(self._builder, *qubits)
             elif "reset" == instruction.name:
                 qis.reset(self._builder, qubits[0])
-            elif "r" == instruction.name:
-                qis.r(self._builder, *instruction.params, *qubits)
             elif "rx" == instruction.name:
                 qis.rx(self._builder, *instruction.params, *qubits)
             elif "ry" == instruction.name:

--- a/tests/test_circuits/basic_gates.py
+++ b/tests/test_circuits/basic_gates.py
@@ -27,8 +27,6 @@ _measurements = {"measure": "mz"}
 
 _rotations = {"rx": "rx", "ry": "ry", "rz": "rz"}
 
-general_r_gate = {"r": "r"}
-
 _two_qubit_gates = {"cx": "cnot", "cz": "cz", "swap": "swap"}
 
 _three_qubit_gates = {"ccx": "ccx"}
@@ -93,17 +91,6 @@ for gate in _rotations.keys():
     name = _fixture_name(gate)
     locals()[name] = _generate_rotation_fixture(gate)
 
-def _generate_r_fixture(gate: str):
-    @pytest.fixture()
-    def test_fixture():
-        circuit = QuantumCircuit(1)
-        getattr(circuit, gate)(0.5, 0.5, 0)
-        return _map_gate_name(gate), circuit
-    return test_fixture()
-
-name = _fixture_name(general_r_gate["r"])
-locals()[name] = _generate_r_fixture(name)
-
 
 def _generate_two_qubit_fixture(gate: str):
     @pytest.fixture()
@@ -155,7 +142,6 @@ for gate in _measurements.keys():
 single_op_tests = [_fixture_name(s) for s in _one_qubit_gates.keys()]
 adj_op_tests = [_fixture_name(s) for s in _adj_gates.keys()]
 rotation_tests = [_fixture_name(s) for s in _rotations.keys()]
-r_test = [_fixture_name(general_r_gate["r"])]
 double_op_tests = [_fixture_name(s) for s in _two_qubit_gates.keys()]
 triple_op_tests = [_fixture_name(s) for s in _three_qubit_gates.keys()]
 measurement_tests = [_fixture_name(s) for s in _measurements.keys()]

--- a/tests/test_circuits/basic_gates.py
+++ b/tests/test_circuits/basic_gates.py
@@ -27,6 +27,8 @@ _measurements = {"measure": "mz"}
 
 _rotations = {"rx": "rx", "ry": "ry", "rz": "rz"}
 
+general_r_gate = {"r": "r"}
+
 _two_qubit_gates = {"cx": "cnot", "cz": "cz", "swap": "swap"}
 
 _three_qubit_gates = {"ccx": "ccx"}
@@ -91,6 +93,17 @@ for gate in _rotations.keys():
     name = _fixture_name(gate)
     locals()[name] = _generate_rotation_fixture(gate)
 
+def _generate_r_fixture(gate: str):
+    @pytest.fixture()
+    def test_fixture():
+        circuit = QuantumCircuit(1)
+        getattr(circuit, gate)(0.5, 0.5, 0)
+        return _map_gate_name(gate), circuit
+    return test_fixture()
+
+name = _fixture_name(general_r_gate["r"])
+locals()[name] = _generate_r_fixture(name)
+
 
 def _generate_two_qubit_fixture(gate: str):
     @pytest.fixture()
@@ -142,6 +155,7 @@ for gate in _measurements.keys():
 single_op_tests = [_fixture_name(s) for s in _one_qubit_gates.keys()]
 adj_op_tests = [_fixture_name(s) for s in _adj_gates.keys()]
 rotation_tests = [_fixture_name(s) for s in _rotations.keys()]
+r_test = [_fixture_name(general_r_gate["r"])]
 double_op_tests = [_fixture_name(s) for s in _two_qubit_gates.keys()]
 triple_op_tests = [_fixture_name(s) for s in _three_qubit_gates.keys()]
 measurement_tests = [_fixture_name(s) for s in _measurements.keys()]

--- a/tests/test_qiskit_qir.py
+++ b/tests/test_qiskit_qir.py
@@ -17,6 +17,7 @@ from test_circuits.basic_gates import (
     single_op_tests,
     adj_op_tests,
     rotation_tests,
+    r_test,
     double_op_tests,
     triple_op_tests,
     measurement_tests,
@@ -116,6 +117,17 @@ def test_rotation_gates(circuit_name, request):
     func = test_utils.get_entry_point_body(generated_qir)
     assert func[0] == test_utils.initialize_call_string()
     assert func[1] == test_utils.rotation_call_string(qir_op, 0.5, 0)
+    assert func[2] == test_utils.return_string()
+    assert len(func) == 3
+
+@pytest.mark.parametrize("circuit_name", r_test)
+def test_r_gate(circuit_name, request):
+    qir_op, circuit = request.getfixturevalue(circuit_name)
+    generated_qir = str(to_qir_module(circuit)[0]).splitlines()
+    test_utils.check_attributes(generated_qir, 1, 0)
+    func = test_utils.get_entry_point_body(generated_qir)
+    assert func[0] == test_utils.initialize_call_string()
+    assert func[1] == test_utils.multiparameter_rotation_call_string(qir_op, 0.5, 0.5, 0)
     assert func[2] == test_utils.return_string()
     assert len(func) == 3
 

--- a/tests/test_qiskit_qir.py
+++ b/tests/test_qiskit_qir.py
@@ -17,7 +17,6 @@ from test_circuits.basic_gates import (
     single_op_tests,
     adj_op_tests,
     rotation_tests,
-    r_test,
     double_op_tests,
     triple_op_tests,
     measurement_tests,
@@ -117,17 +116,6 @@ def test_rotation_gates(circuit_name, request):
     func = test_utils.get_entry_point_body(generated_qir)
     assert func[0] == test_utils.initialize_call_string()
     assert func[1] == test_utils.rotation_call_string(qir_op, 0.5, 0)
-    assert func[2] == test_utils.return_string()
-    assert len(func) == 3
-
-@pytest.mark.parametrize("circuit_name", r_test)
-def test_r_gate(circuit_name, request):
-    qir_op, circuit = request.getfixturevalue(circuit_name)
-    generated_qir = str(to_qir_module(circuit)[0]).splitlines()
-    test_utils.check_attributes(generated_qir, 1, 0)
-    func = test_utils.get_entry_point_body(generated_qir)
-    assert func[0] == test_utils.initialize_call_string()
-    assert func[1] == test_utils.multiparameter_rotation_call_string(qir_op, 0.5, 0.5, 0)
     assert func[2] == test_utils.return_string()
     assert len(func) == 3
 


### PR DESCRIPTION
The Qiskit[RGate](https://docs.quantum.ibm.com/api/qiskit/qiskit.circuit.library.RGate) is one of the native gates of IQM's superconducting device, and in order to use qiskit_qir to translate transpiled Qiskit circuits to QIR supported by IQM software, RGate support needs to be implemented in qiskit_qir and pyqir. 